### PR TITLE
Fix Sideloadly WatchKit error(?)

### DIFF
--- a/.github/workflows/build-and-release-yourself.yml
+++ b/.github/workflows/build-and-release-yourself.yml
@@ -106,10 +106,14 @@ jobs:
           cd "$(dirname "$OUT_IPA")"
           rm -rf Payload
           unzip -q "$(basename "$OUT_IPA")"
+          if [ -d "Payload/Spotify.app/com.apple.WatchPlaceholder" ]; then
+            rm -rf Payload/Spotify.app/com.apple.WatchPlaceholder
+          fi
           if [ -d "Payload/Spotify.app/Watch" ]; then
             rm -rf Payload/Spotify.app/Watch
-            zip -qry "$(basename "$OUT_IPA")" Payload
           fi
+          rm -f "$(basename "$OUT_IPA")"
+          zip -qry "$(basename "$OUT_IPA")" Payload
           rm -rf Payload
 
       - name: Stage alternate app icons

--- a/.github/workflows/buildnopatch.yml
+++ b/.github/workflows/buildnopatch.yml
@@ -155,7 +155,22 @@ jobs:
 
       # NOTE: Removed the post-injection ipapatch step.
       # If you later need it back, restore the "LC-inject zxPluginsInject (ipapatch)" step.
-
+      
+      - name: Strip Watch app (if any survived)
+        run: |
+          cd "$(dirname "$OUT_IPA")"
+          rm -rf Payload
+          unzip -q "$(basename "$OUT_IPA")"
+          if [ -d "Payload/Spotify.app/com.apple.WatchPlaceholder" ]; then
+            rm -rf Payload/Spotify.app/com.apple.WatchPlaceholder
+          fi
+          if [ -d "Payload/Spotify.app/Watch" ]; then
+            rm -rf Payload/Spotify.app/Watch
+          fi
+          rm -f "$(basename "$OUT_IPA")"
+          zip -qry "$(basename "$OUT_IPA")" Payload
+          rm -rf Payload
+          
       - name: Stage alternate app icons
         if: ${{ inputs.ipa_url != '' }}
         run: |

--- a/.github/workflows/buildpatched.yml
+++ b/.github/workflows/buildpatched.yml
@@ -158,10 +158,14 @@ jobs:
           cd "$(dirname "$OUT_IPA")"
           rm -rf Payload
           unzip -q "$(basename "$OUT_IPA")"
+          if [ -d "Payload/Spotify.app/com.apple.WatchPlaceholder" ]; then
+            rm -rf Payload/Spotify.app/com.apple.WatchPlaceholder
+          fi
           if [ -d "Payload/Spotify.app/Watch" ]; then
             rm -rf Payload/Spotify.app/Watch
-            zip -qry "$(basename "$OUT_IPA")" Payload
           fi
+          rm -f "$(basename "$OUT_IPA")"
+          zip -qry "$(basename "$OUT_IPA")" Payload
           rm -rf Payload
 
       - name: Stage alternate app icons

--- a/.github/workflows/buildpatched.yml
+++ b/.github/workflows/buildpatched.yml
@@ -154,7 +154,6 @@ jobs:
           rm -rf Payload
 
       - name: Strip Watch app (if any survived)
-        if: ${{ inputs.ipa_url != '' }}
         run: |
           cd "$(dirname "$OUT_IPA")"
           rm -rf Payload


### PR DESCRIPTION
 this is most likely unneeded but i wanted to save you time if you was going to do it, this specific issue shouldn't be happening for your workflows though
 also adds back the watch strip to buildnopatch at the end incase the script somehow misses it