### PR TITLE
fix(workflows): use correct PlugIns casing for iOS bundle directory

### DIFF
--- a/.github/workflows/buildnopatch.yml
+++ b/.github/workflows/buildnopatch.yml
@@ -146,8 +146,8 @@ jobs:
           rm -rf Payload
           unzip -q "$(basename "$OUT_IPA")"
 
-          mkdir -p "Payload/Spotify.app/Plugins"
-          cp -R "$OPENSPOTIFY_APPEX" "Payload/Spotify.app/Plugins/OpenSpotifySafariExtension.appex"
+          mkdir -p "Payload/Spotify.app/PlugIns"
+          cp -R "$OPENSPOTIFY_APPEX" "Payload/Spotify.app/PlugIns/OpenSpotifySafariExtension.appex"
 
           rm -f "$(basename "$OUT_IPA")"
           zip -qry "$(basename "$OUT_IPA")" Payload

--- a/.github/workflows/buildpatched.yml
+++ b/.github/workflows/buildpatched.yml
@@ -138,16 +138,16 @@ jobs:
           ipapatch --input "$OUT_IPA" --inplace --noconfirm \
                    --dylib packages/zxPluginsInject.dylib
 
-      - name: Inject OpeninSafariSpotify extension into IPA Plugins
+      - name: Inject OpeninSafariSpotify extension into IPA PlugIns
         if: ${{ inputs.ipa_url != '' }}
         run: |
           cd "$(dirname "$OUT_IPA")"
           rm -rf Payload
           unzip -q "$(basename "$OUT_IPA")"
 
-          mkdir -p "Payload/Spotify.app/Plugins"
-          rm -rf "Payload/Spotify.app/Plugins/OpenSpotifySafariExtension.appex"
-          cp -R "$OPENSPOTIFY_APPEX" "Payload/Spotify.app/Plugins/OpenSpotifySafariExtension.appex"
+          mkdir -p "Payload/Spotify.app/PlugIns"
+          rm -rf "Payload/Spotify.app/PlugIns/OpenSpotifySafariExtension.appex"
+          cp -R "$OPENSPOTIFY_APPEX" "Payload/Spotify.app/PlugIns/OpenSpotifySafariExtension.appex"
 
           # Repack only the Payload folder back into the IPA
           zip -qry "$(basename "$OUT_IPA")" Payload


### PR DESCRIPTION
iOS bundles use `PlugIns` (capital I), but the workflows create `Plugins` (lowercase i).
This means `OpenSpotifySafariExtension.appex` ends up in a directory iOS doesn't scan, so the Safari extension never registers in Settings → Safari → Extensions

Verified by extracting the v6.6.4 IPA, manually renaming `Plugins` → `PlugIns`, and resigning — the extension shows up correctly after.