### PR TITLE
workflows: mask the IPA url

### DIFF
--- a/.github/workflows/build-and-release-yourself.yml
+++ b/.github/workflows/build-and-release-yourself.yml
@@ -34,9 +34,6 @@ jobs:
 
       - uses: levibostian/action-hide-sensitive-inputs@v1
 
-      - name: Mask vanilla IPA url
-        run: echo "::add-mask::${{ inputs.ipa_url }}"
-
       - name: Download IPA
         run: |
           wget "${{ inputs.ipa_url }}" --no-verbose -O ${{ github.workspace }}/spotify.ipa

--- a/.github/workflows/build-and-release-yourself.yml
+++ b/.github/workflows/build-and-release-yourself.yml
@@ -34,6 +34,9 @@ jobs:
 
       - uses: levibostian/action-hide-sensitive-inputs@v1
 
+      - name: Mask vanilla IPA url
+        run: echo "::add-mask::${{ inputs.ipa_url }}"
+
       - name: Download IPA
         run: |
           wget "${{ inputs.ipa_url }}" --no-verbose -O ${{ github.workspace }}/spotify.ipa

--- a/.github/workflows/buildnopatch.yml
+++ b/.github/workflows/buildnopatch.yml
@@ -79,6 +79,9 @@ jobs:
 
       # ─── IPA build (only when ipa_url is provided) ───────────────────
 
+      - name: Mask vanilla IPA url
+        run: echo "::add-mask::${{ inputs.ipa_url }}"
+
       - name: Validate vanilla IPA
         if: ${{ inputs.ipa_url != '' }}
         run: |

--- a/.github/workflows/buildnopatch.yml
+++ b/.github/workflows/buildnopatch.yml
@@ -79,8 +79,7 @@ jobs:
 
       # ─── IPA build (only when ipa_url is provided) ───────────────────
 
-      - name: Mask vanilla IPA url
-        run: echo "::add-mask::${{ inputs.ipa_url }}"
+      - uses: levibostian/action-hide-sensitive-inputs@v1 
 
       - name: Validate vanilla IPA
         if: ${{ inputs.ipa_url != '' }}

--- a/.github/workflows/buildpatched.yml
+++ b/.github/workflows/buildpatched.yml
@@ -77,6 +77,9 @@ jobs:
           if-no-files-found: error
 
       # ─── IPA build (only when ipa_url is provided) ───────────────────
+      
+      - name: Mask vanilla IPA url
+        run: echo "::add-mask::${{ inputs.ipa_url }}"
 
       - name: Validate vanilla IPA
         if: ${{ inputs.ipa_url != '' }}

--- a/.github/workflows/buildpatched.yml
+++ b/.github/workflows/buildpatched.yml
@@ -78,8 +78,7 @@ jobs:
 
       # ─── IPA build (only when ipa_url is provided) ───────────────────
       
-      - name: Mask vanilla IPA url
-        run: echo "::add-mask::${{ inputs.ipa_url }}"
+      - uses: levibostian/action-hide-sensitive-inputs@v1
 
       - name: Validate vanilla IPA
         if: ${{ inputs.ipa_url != '' }}


### PR DESCRIPTION
# self-explanatory!
this is so then the user's IPA url to their decrypted Spotify app isn't leaked in the workflow logs
<img width="549" height="94" alt="chrome_5SOT6z9y0H" src="https://github.com/user-attachments/assets/3a5f0b87-a0fc-4c0b-8cb4-c77f56480758" />

# result

<img width="1035" height="505" alt="chrome_Cz3Aes3EOM" src="https://github.com/user-attachments/assets/5dcb5c28-720f-4fb4-96c0-53465cd21a7c" />
