### PR TITLE
Fix workflow not building if there is no IPA

### DIFF
--- a/.github/workflows/buildnopatch.yml
+++ b/.github/workflows/buildnopatch.yml
@@ -159,6 +159,7 @@ jobs:
       # If you later need it back, restore the "LC-inject zxPluginsInject (ipapatch)" step.
       
       - name: Strip Watch app (if any survived)
+        if: ${{ inputs.ipa_url != '' }}
         run: |
           cd "$(dirname "$OUT_IPA")"
           rm -rf Payload

--- a/.github/workflows/buildpatched.yml
+++ b/.github/workflows/buildpatched.yml
@@ -156,6 +156,7 @@ jobs:
           rm -rf Payload
 
       - name: Strip Watch app (if any survived)
+        if: ${{ inputs.ipa_url != '' }}
         run: |
           cd "$(dirname "$OUT_IPA")"
           rm -rf Payload


### PR DESCRIPTION
Just a simple fix for the workflow failing if no IPA was provided 