### PR TITLE
update versions + wording change

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # EeveeSpotifyReincarnated
 
 **Maintainers:** [jaydenjcpy](https://github.com/jaydenjcpy) & [faroukbmiled](https://github.com/faroukbmiled) & [Mod4](https://github.com/M0d-4) <br />
-**Last Update:** `6/15/26` **Spotify Version:** `9.1.56`
+**Last Update:** `6/28/26` **Spotify Version:** `9.1.60`
 
 This tweak makes Spotify think you have a Premium subscription, granting free listening, just like Spotilife, and provides some additional features like custom lyrics.
 

--- a/common_issues.md
+++ b/common_issues.md
@@ -2,9 +2,9 @@ On this page, you'll find a detailed FAQ covering various topics related to Eeve
 
 # Versions and Support
 
-EeveeSpotify currently supports Spotify version **9.1.50** (the latest version compatible with iOS 16.1+). 
+EeveeSpotify currently supports Spotify version **9.1.60** (the latest version compatible with iOS 16.1+). 
 
-If you are jailbroken, install the latest .deb from the [releases page](https://github.com/jaydenjcpy/EeveeSpotifyReincarnated/releases), along with Spotify 9.1.50 from the App Store. After installation, open the EeveeSpotify settings (accessible from your Spotify profile settings) and reset data so it will properly patch Premium features.
+If you are jailbroken, install the latest .deb from the [releases page](https://github.com/jaydenjcpy/EeveeSpotifyReincarnated/releases), along with the latest Spotify from the App Store. After installation, open the EeveeSpotify settings (accessible from your Spotify profile settings) and reset data so it will properly patch Premium features.
 
 For non-jailbroken devices, use the patched IPA files available in the releases. You can install these using:
 - **TrollStore** (recommended for iOS 14-16.6.1, 17.0)


### PR DESCRIPTION
changing the "download Spotify x.x.xx from the App Store" every release seemed stupid so now its just latest spotify from the app store