### PR TITLE
Add automatic RootHide package builds

### DIFF
--- a/.github/workflows/builddeb.yml
+++ b/.github/workflows/builddeb.yml
@@ -1,4 +1,4 @@
-name: Build rootless .deb + Draft Release
+name: Build rootless + RootHide .debs + Draft Release
 
 on:
   workflow_dispatch:
@@ -19,15 +19,26 @@ on:
         options: ["false", "true"]
 
 env:
-  THEOS: ${{ github.workspace }}/theos
   SWIFTPROTOBUF_VERSION: "1.29.0"
 
 jobs:
   build-debs:
-    name: Build arm64 .deb
+    name: Build ${{ matrix.label }} .deb
     runs-on: macos-latest
-    permissions:
-      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scheme: rootless
+            label: rootless
+            theos_repository: theos/theos
+          - scheme: roothide
+            label: RootHide
+            theos_repository: roothide/theos
+
+    env:
+      THEOS: ${{ github.workspace }}/theos
+      THEOS_PACKAGE_SCHEME: ${{ matrix.scheme }}
 
     steps:
       - name: Checkout repo
@@ -40,10 +51,10 @@ jobs:
         with:
           xcode-version: "26.3.0"
 
-      - name: Checkout Theos
+      - name: Checkout ${{ matrix.label }} Theos
         uses: actions/checkout@v4
         with:
-          repository: theos/theos
+          repository: ${{ matrix.theos_repository }}
           path: ${{ github.workspace }}/theos
           submodules: recursive
 
@@ -52,50 +63,64 @@ jobs:
           brew install make dpkg ldid
           echo "$(brew --prefix make)/libexec/gnubin" >> "$GITHUB_PATH"
 
-      - name: Build EeveeSwiftProtobuf.framework (required once)
-        run: |
-          make build-eeveeswiftprotobuf
+      - name: Build EeveeSwiftProtobuf.framework
+        run: make build-eeveeswiftprotobuf
 
-      - name: Install EeveeSwiftProtobuf into Theos
-        run: |
-          # Find the built framework (adjust if your build script outputs somewhere specific)
-          FW=$(find "$GITHUB_WORKSPACE" -name "EeveeSwiftProtobuf.framework" -type d | head -n 1)
-          [ -n "$FW" ] || { echo "EeveeSwiftProtobuf.framework not found" >&2; exit 1; }
-
-          mkdir -p "$THEOS/vendor/lib"
-          rm -rf "$THEOS/vendor/lib/EeveeSwiftProtobuf.framework"
-          cp -R "$FW" "$THEOS/vendor/lib/EeveeSwiftProtobuf.framework"
-
-
-      - name: Build arm64 .deb
+      - name: Build ${{ matrix.label }} .deb
         env:
           REPO_SLUG: ${{ github.repository }}
         run: |
           make clean || true
-          make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME="rootless"
-          ls -la packages || true
+          make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME="${{ matrix.scheme }}"
+          ls -la packages
 
-      - name: Save arm64 artifact
+      - name: Stage ${{ matrix.label }} artifact
         run: |
           mkdir -p Outputs/DEBS
-          # pick newest deb produced by Theos
-          ARM64_DEB="$(ls -t packages/*.deb | head -n 1)"
-          cp -f "$ARM64_DEB" "Outputs/DEBS/$(basename "$ARM64_DEB" .deb).deb"
-          echo "ARM64_DEB=Outputs/DEBS/$(basename "$ARM64_DEB" .deb).deb" >> "$GITHUB_ENV"
+          DEB_PATH="$(ls -t packages/*.deb | head -n 1)"
+          [ -n "$DEB_PATH" ] || { echo "No .deb produced" >&2; exit 1; }
+          if [ "${{ matrix.scheme }}" = "roothide" ]; then
+            OUT_NAME="$(basename "$DEB_PATH" .deb)-roothide.deb"
+          else
+            OUT_NAME="$(basename "$DEB_PATH")"
+          fi
+          cp -f "$DEB_PATH" "Outputs/DEBS/$OUT_NAME"
 
-      - name: Upload deb artifacts
+      - name: Validate package metadata and layout
+        run: |
+          DEB_PATH="$(find Outputs/DEBS -name '*.deb' -type f | head -n 1)"
+          dpkg-deb --info "$DEB_PATH"
+          dpkg-deb --contents "$DEB_PATH"
+          if [ "${{ matrix.scheme }}" = "roothide" ]; then
+            [ "$(dpkg-deb -f "$DEB_PATH" Architecture)" = "iphoneos-arm64e" ]
+          fi
+
+      - name: Upload ${{ matrix.label }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: EeveeSpotify-DEBS
+          name: EeveeSpotify-${{ matrix.label }}-DEB
           path: Outputs/DEBS/*.deb
           if-no-files-found: error
 
-      - name: Draft GitHub Release and attach .debs
+  draft-release:
+    name: Create draft release
+    needs: build-debs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download both packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: EeveeSpotify-*-DEB
+          path: Outputs/DEBS
+          merge-multiple: true
+
+      - name: Draft GitHub Release and attach both .debs
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag }}
           name: ${{ inputs.release_name != '' && inputs.release_name || inputs.tag }}
           draft: true
           prerelease: ${{ inputs.prerelease == 'true' }}
-          files: |
-            ${{ env.ARM64_DEB }}
+          files: Outputs/DEBS/*.deb

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ EeveeSpotify_CFLAGS = -fobjc-arc -ISources/EeveeSpotifyC/include -Os
 # RootHide's compatibility implementation of libroot resolves jailbreak paths
 # through libroothide at runtime. Rootless builds continue to use libroot.
 ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
+EeveeSpotify_SWIFTFLAGS += -D ROOTHIDE
 EeveeSpotify_LDFLAGS += -lroothide -Xlinker -rpath -Xlinker @loader_path/.jbroot/Library/Frameworks
 else
 EeveeSpotify_LDFLAGS += -lroot

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ internal-stage::
 	# SwiftProtobuf so the @objc class names don't collide with the
 	# SwiftProtobuf statically embedded in SpotifyShared.framework.
 	mkdir -p $(THEOS_STAGING_DIR)/Library/Frameworks
-	cp -r $(THEOS)/lib/iphone/rootless/EeveeSwiftProtobuf.framework $(THEOS_STAGING_DIR)/Library/Frameworks/
+	cp -r $(THEOS)/lib/iphone/$(or $(THEOS_PACKAGE_SCHEME),rootless)/EeveeSwiftProtobuf.framework $(THEOS_STAGING_DIR)/Library/Frameworks/
 
 # Build EeveeSwiftProtobuf.framework from apple/swift-protobuf source. Run
 # this once before `make package`. Re-run if SWIFTPROTOBUF_VERSION changes

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ EeveeSpotify_SWIFTFLAGS = -ISources/EeveeSpotifyC/include -Osize
 EeveeSpotify_EXTRA_FRAMEWORKS = EeveeSwiftProtobuf
 EeveeSpotify_CFLAGS = -fobjc-arc -ISources/EeveeSpotifyC/include -Os
 
+# RootHide's compatibility implementation of libroot resolves jailbreak paths
+# through libroothide at runtime. Rootless builds continue to use libroot.
+ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
+EeveeSpotify_LDFLAGS += -lroothide
+endif
+
 # Sideload compatibility (keychain redirect, group containers, CloudKit) is
 # handled out-of-process by modules/zxPluginsInject — LC-injected via ipapatch
 # in build-ipa-local.sh and the GitHub workflow. No flags needed here.

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ EeveeSpotify_CFLAGS = -fobjc-arc -ISources/EeveeSpotifyC/include -Os
 # through libroothide at runtime. Rootless builds continue to use libroot.
 ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
 EeveeSpotify_LDFLAGS += -lroothide
+else
+EeveeSpotify_LDFLAGS += -lroot
 endif
 
 # Sideload compatibility (keychain redirect, group containers, CloudKit) is

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ EeveeSpotify_CFLAGS = -fobjc-arc -ISources/EeveeSpotifyC/include -Os
 # RootHide's compatibility implementation of libroot resolves jailbreak paths
 # through libroothide at runtime. Rootless builds continue to use libroot.
 ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
-EeveeSpotify_LDFLAGS += -lroothide
+EeveeSpotify_LDFLAGS += -lroothide -Xlinker -rpath -Xlinker @loader_path/.jbroot/Library/Frameworks
 else
 EeveeSpotify_LDFLAGS += -lroot
 endif

--- a/Sources/EeveeSpotify/EeveeAdBlockerExtended.x.swift
+++ b/Sources/EeveeSpotify/EeveeAdBlockerExtended.x.swift
@@ -6,7 +6,14 @@
 import Orion
 import Foundation
 
-struct EeveeAdBlockerExtendedGroup: HookGroup {}
+// Keep every target in its own group. Orion activates a group atomically and
+// treats one missing/incompatible descriptor as fatal, which made a single
+// Spotify service rename crash the whole application on launch.
+struct AdsServiceImplGroup: HookGroup {}
+struct InStreamAdsServiceGroup: HookGroup {}
+struct EmbeddedNPVServiceGroup: HookGroup {}
+struct NativeAdsLoggerServiceGroup: HookGroup {}
+struct SponsoredCtxAttachmentGroup: HookGroup {}
 
 private let killAdsServiceImpl         = true
 private let killInStreamAdsService     = true
@@ -21,7 +28,7 @@ private func adlog(_ what: String) {
 }
 
 class AdsServiceImplKill: ClassHook<NSObject> {
-    typealias Group = EeveeAdBlockerExtendedGroup
+    typealias Group = AdsServiceImplGroup
     static let targetName: String = "_TtC19AdsPlatform_AdsImpl14AdsServiceImpl"
     func load() {
         if killAdsServiceImpl { adlog("AdsServiceImpl.load"); return }
@@ -30,7 +37,7 @@ class AdsServiceImplKill: ClassHook<NSObject> {
 }
 
 class InStreamAdsServiceKill: ClassHook<NSObject> {
-    typealias Group = EeveeAdBlockerExtendedGroup
+    typealias Group = InStreamAdsServiceGroup
     static let targetName: String = "_TtC29AdsNowPlaying_InStreamAdsImpl18InStreamAdsService"
     func load() {
         if killInStreamAdsService { adlog("InStreamAdsService.load"); return }
@@ -39,7 +46,7 @@ class InStreamAdsServiceKill: ClassHook<NSObject> {
 }
 
 class EmbeddedNPVServiceImplKill: ClassHook<NSObject> {
-    typealias Group = EeveeAdBlockerExtendedGroup
+    typealias Group = EmbeddedNPVServiceGroup
     static let targetName: String = "_TtC29AdsNowPlaying_EmbeddedNPVImpl22EmbeddedNPVServiceImpl"
     func load() {
         if killEmbeddedNPVService { adlog("EmbeddedNPVServiceImpl.load"); return }
@@ -48,7 +55,7 @@ class EmbeddedNPVServiceImplKill: ClassHook<NSObject> {
 }
 
 class NativeAdsLoggerServiceImplKill: ClassHook<NSObject> {
-    typealias Group = EeveeAdBlockerExtendedGroup
+    typealias Group = NativeAdsLoggerServiceGroup
     static let targetName: String = "_TtC20NativeAds_LoggerImpl26NativeAdsLoggerServiceImpl"
     func load() {
         if killNativeAdsLoggerService { adlog("NativeAdsLoggerServiceImpl.load"); return }
@@ -59,7 +66,7 @@ class NativeAdsLoggerServiceImplKill: ClassHook<NSObject> {
 // Passive log only — returning nil from init would crash the alloc chain.
 // Upstream events are starved by killing AdsServiceImpl above.
 class SponsoredCtxAttachmentProbe: ClassHook<NSObject> {
-    typealias Group = EeveeAdBlockerExtendedGroup
+    typealias Group = SponsoredCtxAttachmentGroup
     static let targetName: String =
         "_TtC48AdsEmbedded_AdsSponsoredContextNPBAttachmentImpl25AdModelChangedEventSource"
     func `init`() -> Target {
@@ -71,19 +78,37 @@ class SponsoredCtxAttachmentProbe: ClassHook<NSObject> {
 }
 
 func activateEeveeAdBlockerExtended() {
-    let probes: [String] = [
-        "_TtC19AdsPlatform_AdsImpl14AdsServiceImpl",
-        "_TtC29AdsNowPlaying_InStreamAdsImpl18InStreamAdsService",
-        "_TtC29AdsNowPlaying_EmbeddedNPVImpl22EmbeddedNPVServiceImpl",
-        "_TtC20NativeAds_LoggerImpl26NativeAdsLoggerServiceImpl",
+    let loadSelector = Selector(("load"))
+    let initSelector = Selector(("init"))
+
+    let loadTargets: [(String, String, () -> Void)] = [
+        (AdsServiceImplKill.targetName, "AdsServiceImpl", { AdsServiceImplGroup().activate() }),
+        (InStreamAdsServiceKill.targetName, "InStreamAdsService", { InStreamAdsServiceGroup().activate() }),
+        (EmbeddedNPVServiceImplKill.targetName, "EmbeddedNPVServiceImpl", { EmbeddedNPVServiceGroup().activate() }),
+        (NativeAdsLoggerServiceImplKill.targetName, "NativeAdsLoggerServiceImpl", { NativeAdsLoggerServiceGroup().activate() }),
     ]
-    let presentCount = probes.filter { NSClassFromString($0) != nil }.count
-    NSLog("[EeveeSpotify][AdBlock] target classes resolved: %d/%d",
-          presentCount, probes.count)
-    guard presentCount > 0 else {
-        NSLog("[EeveeSpotify][AdBlock] no target classes present; skip activation")
-        return
+
+    var activated = 0
+    for (className, label, activate) in loadTargets {
+        guard let cls = NSClassFromString(className),
+              class_getInstanceMethod(cls, loadSelector) != nil else {
+            NSLog("[EeveeSpotify][AdBlock] %@/load unavailable; skipping", label)
+            continue
+        }
+        activate()
+        activated += 1
+        NSLog("[EeveeSpotify][AdBlock] %@ hook activated", label)
     }
-    EeveeAdBlockerExtendedGroup().activate()
-    NSLog("[EeveeSpotify][AdBlock] EeveeAdBlockerExtendedGroup activated")
+
+    if let cls = NSClassFromString(SponsoredCtxAttachmentProbe.targetName),
+       class_getInstanceMethod(cls, initSelector) != nil {
+        SponsoredCtxAttachmentGroup().activate()
+        activated += 1
+        NSLog("[EeveeSpotify][AdBlock] SponsoredCtxAttachment hook activated")
+    } else {
+        NSLog("[EeveeSpotify][AdBlock] SponsoredCtxAttachment/init unavailable; skipping")
+    }
+
+    NSLog("[EeveeSpotify][AdBlock] activated %d/%d compatible extended hooks",
+          activated, loadTargets.count + 1)
 }

--- a/Sources/EeveeSpotify/EeveeAdBlockerExtended.x.swift
+++ b/Sources/EeveeSpotify/EeveeAdBlockerExtended.x.swift
@@ -6,14 +6,18 @@
 import Orion
 import Foundation
 
-// Keep every target in its own group. Orion activates a group atomically and
-// treats one missing/incompatible descriptor as fatal, which made a single
-// Spotify service rename crash the whole application on launch.
+struct EeveeAdBlockerExtendedGroup: HookGroup {}
+
+#if ROOTHIDE
+// RootHide can expose Spotify's Swift service classes at different points
+// during injection. Isolate every descriptor so an unavailable service does
+// not make Orion reject all extended hooks and terminate the application.
 struct AdsServiceImplGroup: HookGroup {}
 struct InStreamAdsServiceGroup: HookGroup {}
 struct EmbeddedNPVServiceGroup: HookGroup {}
 struct NativeAdsLoggerServiceGroup: HookGroup {}
 struct SponsoredCtxAttachmentGroup: HookGroup {}
+#endif
 
 private let killAdsServiceImpl         = true
 private let killInStreamAdsService     = true
@@ -28,7 +32,11 @@ private func adlog(_ what: String) {
 }
 
 class AdsServiceImplKill: ClassHook<NSObject> {
+    #if ROOTHIDE
     typealias Group = AdsServiceImplGroup
+    #else
+    typealias Group = EeveeAdBlockerExtendedGroup
+    #endif
     static let targetName: String = "_TtC19AdsPlatform_AdsImpl14AdsServiceImpl"
     func load() {
         if killAdsServiceImpl { adlog("AdsServiceImpl.load"); return }
@@ -37,7 +45,11 @@ class AdsServiceImplKill: ClassHook<NSObject> {
 }
 
 class InStreamAdsServiceKill: ClassHook<NSObject> {
+    #if ROOTHIDE
     typealias Group = InStreamAdsServiceGroup
+    #else
+    typealias Group = EeveeAdBlockerExtendedGroup
+    #endif
     static let targetName: String = "_TtC29AdsNowPlaying_InStreamAdsImpl18InStreamAdsService"
     func load() {
         if killInStreamAdsService { adlog("InStreamAdsService.load"); return }
@@ -46,7 +58,11 @@ class InStreamAdsServiceKill: ClassHook<NSObject> {
 }
 
 class EmbeddedNPVServiceImplKill: ClassHook<NSObject> {
+    #if ROOTHIDE
     typealias Group = EmbeddedNPVServiceGroup
+    #else
+    typealias Group = EeveeAdBlockerExtendedGroup
+    #endif
     static let targetName: String = "_TtC29AdsNowPlaying_EmbeddedNPVImpl22EmbeddedNPVServiceImpl"
     func load() {
         if killEmbeddedNPVService { adlog("EmbeddedNPVServiceImpl.load"); return }
@@ -55,7 +71,11 @@ class EmbeddedNPVServiceImplKill: ClassHook<NSObject> {
 }
 
 class NativeAdsLoggerServiceImplKill: ClassHook<NSObject> {
+    #if ROOTHIDE
     typealias Group = NativeAdsLoggerServiceGroup
+    #else
+    typealias Group = EeveeAdBlockerExtendedGroup
+    #endif
     static let targetName: String = "_TtC20NativeAds_LoggerImpl26NativeAdsLoggerServiceImpl"
     func load() {
         if killNativeAdsLoggerService { adlog("NativeAdsLoggerServiceImpl.load"); return }
@@ -66,7 +86,11 @@ class NativeAdsLoggerServiceImplKill: ClassHook<NSObject> {
 // Passive log only — returning nil from init would crash the alloc chain.
 // Upstream events are starved by killing AdsServiceImpl above.
 class SponsoredCtxAttachmentProbe: ClassHook<NSObject> {
+    #if ROOTHIDE
     typealias Group = SponsoredCtxAttachmentGroup
+    #else
+    typealias Group = EeveeAdBlockerExtendedGroup
+    #endif
     static let targetName: String =
         "_TtC48AdsEmbedded_AdsSponsoredContextNPBAttachmentImpl25AdModelChangedEventSource"
     func `init`() -> Target {
@@ -78,6 +102,7 @@ class SponsoredCtxAttachmentProbe: ClassHook<NSObject> {
 }
 
 func activateEeveeAdBlockerExtended() {
+    #if ROOTHIDE
     let loadSelector = Selector(("load"))
     let initSelector = Selector(("init"))
 
@@ -111,4 +136,21 @@ func activateEeveeAdBlockerExtended() {
 
     NSLog("[EeveeSpotify][AdBlock] activated %d/%d compatible extended hooks",
           activated, loadTargets.count + 1)
+    #else
+    let probes: [String] = [
+        "_TtC19AdsPlatform_AdsImpl14AdsServiceImpl",
+        "_TtC29AdsNowPlaying_InStreamAdsImpl18InStreamAdsService",
+        "_TtC29AdsNowPlaying_EmbeddedNPVImpl22EmbeddedNPVServiceImpl",
+        "_TtC20NativeAds_LoggerImpl26NativeAdsLoggerServiceImpl",
+    ]
+    let presentCount = probes.filter { NSClassFromString($0) != nil }.count
+    NSLog("[EeveeSpotify][AdBlock] target classes resolved: %d/%d",
+          presentCount, probes.count)
+    guard presentCount > 0 else {
+        NSLog("[EeveeSpotify][AdBlock] no target classes present; skip activation")
+        return
+    }
+    EeveeAdBlockerExtendedGroup().activate()
+    NSLog("[EeveeSpotify][AdBlock] EeveeAdBlockerExtendedGroup activated")
+    #endif
 }

--- a/Sources/EeveeSpotify/Premium/Helpers/BundleHelper.swift
+++ b/Sources/EeveeSpotify/Premium/Helpers/BundleHelper.swift
@@ -1,6 +1,6 @@
 import Foundation
 import SwiftUI
-import libroot
+import EeveeSpotifyC
 
 class BundleHelper {
     private let bundleName = "EeveeSpotify"
@@ -20,7 +20,7 @@ class BundleHelper {
         } 
         // If not found, try locating in file system (jailbreak path)
         else {
-            let jbPath = jbRootPath("/Library/Application Support/\(bundleName).bundle")
+            let jbPath = EeveeJBRootPath("/Library/Application Support/\(bundleName).bundle")
             if let b = Bundle(path: jbPath) {
                 self.bundle = b
                 NSLog("[EeveeSpotify] Loaded bundle from filesystem: \(jbPath)")

--- a/Sources/EeveeSpotify/Tweak.x.swift
+++ b/Sources/EeveeSpotify/Tweak.x.swift
@@ -235,15 +235,9 @@ struct EeveeSpotify: Tweak {
 
         activateEeveeCrossfadeForce()
 
-        // The extended ad blocker is experimental and its service hooks do not
-        // all exist with the same Objective-C signatures in Spotify 9.1.x.
-        // Orion treats one incompatible descriptor as fatal during startup, so
-        // keep the stable ad-blocking paths enabled and skip only this group.
-        if EeveeSpotify.hookTarget == .v91 {
-            NSLog("[EeveeSpotify][AdBlock] skipping extended group on Spotify 9.1.x")
-        } else {
-            activateEeveeAdBlockerExtended()
-        }
+        // Each experimental ad surface is independently capability-gated, so a
+        // service renamed by Spotify cannot prevent the other hooks from loading.
+        activateEeveeAdBlockerExtended()
 
         // Block premium upsell / "Like listening without limits?" popups.
         activateUpsellPopupBlocker()

--- a/Sources/EeveeSpotify/Tweak.x.swift
+++ b/Sources/EeveeSpotify/Tweak.x.swift
@@ -235,8 +235,7 @@ struct EeveeSpotify: Tweak {
 
         activateEeveeCrossfadeForce()
 
-        // Each experimental ad surface is independently capability-gated, so a
-        // service renamed by Spotify cannot prevent the other hooks from loading.
+        // TESTING: extended ad blocker (NPV/lyrics ad, home brand-ads, in-stream).
         activateEeveeAdBlockerExtended()
 
         // Block premium upsell / "Like listening without limits?" popups.

--- a/Sources/EeveeSpotify/Tweak.x.swift
+++ b/Sources/EeveeSpotify/Tweak.x.swift
@@ -235,8 +235,15 @@ struct EeveeSpotify: Tweak {
 
         activateEeveeCrossfadeForce()
 
-        // TESTING: extended ad blocker (NPV/lyrics ad, home brand-ads, in-stream).
-        activateEeveeAdBlockerExtended()
+        // The extended ad blocker is experimental and its service hooks do not
+        // all exist with the same Objective-C signatures in Spotify 9.1.x.
+        // Orion treats one incompatible descriptor as fatal during startup, so
+        // keep the stable ad-blocking paths enabled and skip only this group.
+        if EeveeSpotify.hookTarget == .v91 {
+            NSLog("[EeveeSpotify][AdBlock] skipping extended group on Spotify 9.1.x")
+        } else {
+            activateEeveeAdBlockerExtended()
+        }
 
         // Block premium upsell / "Like listening without limits?" popups.
         activateUpsellPopupBlocker()

--- a/Sources/EeveeSpotifyC/Tweak.m
+++ b/Sources/EeveeSpotifyC/Tweak.m
@@ -3,6 +3,20 @@
 #import <objc/message.h>
 #import "Tweak.h"
 
+#if THEOS_PACKAGE_SCHEME_ROOTHIDE
+#import <roothide.h>
+#else
+#import <libroot.h>
+#endif
+
+NSString *EeveeJBRootPath(NSString *path) {
+#if THEOS_PACKAGE_SCHEME_ROOTHIDE
+    return jbroot(path);
+#else
+    return JBROOT_PATH_NSSTRING(path);
+#endif
+}
+
 void EeveeSBInvokeSeekDouble(id target, SEL selector, double argument) {
     if (!target || !selector) return;
     typedef id (*SeekFn)(id, SEL, double);

--- a/Sources/EeveeSpotifyC/include/Tweak.h
+++ b/Sources/EeveeSpotifyC/include/Tweak.h
@@ -3,5 +3,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 void EeveeSBInvokeSeekDouble(id target, SEL selector, double argument);
+NSString *EeveeJBRootPath(NSString *path);
 
 NS_ASSUME_NONNULL_END

--- a/Tools/SwiftProtobufBuild/build-eeveeswiftprotobuf.sh
+++ b/Tools/SwiftProtobufBuild/build-eeveeswiftprotobuf.sh
@@ -20,6 +20,12 @@ PACKAGE_SCHEME="${THEOS_PACKAGE_SCHEME:-rootless}"
 OUT="$THEOS/lib/iphone/${PACKAGE_SCHEME}/${MODULE}.framework"
 DEPLOY_TARGET="${DEPLOY_TARGET:-14.0}"
 
+if [ "$PACKAGE_SCHEME" = "roothide" ]; then
+    INSTALL_NAME="@loader_path/.jbroot/Library/Frameworks/${MODULE}.framework/${MODULE}"
+else
+    INSTALL_NAME="@rpath/${MODULE}.framework/${MODULE}"
+fi
+
 [ -n "${THEOS:-}" ] || { echo "THEOS env not set"; exit 1; }
 
 color() { printf '\033[1;32m==> %s\033[0m\n' "$*"; }
@@ -45,7 +51,7 @@ build_arch() {
         -module-name "$MODULE" \
         -enable-library-evolution -emit-module-interface \
         -Xfrontend -enable-testing -parse-as-library \
-        -Xlinker -install_name -Xlinker "@rpath/${MODULE}.framework/${MODULE}" \
+        -Xlinker -install_name -Xlinker "$INSTALL_NAME" \
         -Xlinker -application_extension \
         -o "$OBJDIR/${MODULE}" \
         -emit-module-path "$OBJDIR/${MODULE}.swiftmodule" \
@@ -60,6 +66,12 @@ rm -rf "$OUT"
 mkdir -p "$OUT/Modules/${MODULE}.swiftmodule"
 
 lipo -create "$SRC/build-arm64/${MODULE}" "$SRC/build-arm64e/${MODULE}" -output "$OUT/${MODULE}"
+
+# RootHide enforces signatures on injected dependencies too. Theos signs the
+# tweak binary, but this framework is assembled manually and must be signed
+# before it is copied into the package.
+command -v ldid >/dev/null 2>&1 || { echo "ldid not found"; exit 1; }
+ldid -S "$OUT/${MODULE}"
 
 for ARCH in arm64 arm64e; do
     OBJDIR="$SRC/build-$ARCH"

--- a/Tools/SwiftProtobufBuild/build-eeveeswiftprotobuf.sh
+++ b/Tools/SwiftProtobufBuild/build-eeveeswiftprotobuf.sh
@@ -4,7 +4,7 @@
 # with the SwiftProtobuf statically embedded in SpotifyShared.framework.
 #
 # Outputs a fat (arm64+arm64e) framework at:
-#   $THEOS/lib/iphone/rootless/EeveeSwiftProtobuf.framework
+#   $THEOS/lib/iphone/$THEOS_PACKAGE_SCHEME/EeveeSwiftProtobuf.framework
 #
 # Why we do this instead of using the prebuilt SwiftProtobuf deb:
 # duplicate-class warnings + SIGSEGV crashes when both copies (ours +
@@ -16,7 +16,8 @@ set -euo pipefail
 VERSION="${SWIFTPROTOBUF_VERSION:-1.29.0}"
 SRC="${SRC_DIR:-/tmp/swiftprotobuf-build}"
 MODULE="EeveeSwiftProtobuf"
-OUT="$THEOS/lib/iphone/rootless/${MODULE}.framework"
+PACKAGE_SCHEME="${THEOS_PACKAGE_SCHEME:-rootless}"
+OUT="$THEOS/lib/iphone/${PACKAGE_SCHEME}/${MODULE}.framework"
 DEPLOY_TARGET="${DEPLOY_TARGET:-14.0}"
 
 [ -n "${THEOS:-}" ] || { echo "THEOS env not set"; exit 1; }

--- a/Tools/SwiftProtobufBuild/build-eeveeswiftprotobuf.sh
+++ b/Tools/SwiftProtobufBuild/build-eeveeswiftprotobuf.sh
@@ -67,11 +67,12 @@ mkdir -p "$OUT/Modules/${MODULE}.swiftmodule"
 
 lipo -create "$SRC/build-arm64/${MODULE}" "$SRC/build-arm64e/${MODULE}" -output "$OUT/${MODULE}"
 
-# RootHide enforces signatures on injected dependencies too. Theos signs the
-# tweak binary, but this framework is assembled manually and must be signed
-# before it is copied into the package.
-command -v ldid >/dev/null 2>&1 || { echo "ldid not found"; exit 1; }
-ldid -S "$OUT/${MODULE}"
+# RootHide enforces signatures on injected dependencies too. Keep the classic
+# rootless framework build unchanged; only its RootHide counterpart needs this.
+if [ "$PACKAGE_SCHEME" = "roothide" ]; then
+    command -v ldid >/dev/null 2>&1 || { echo "ldid not found"; exit 1; }
+    ldid -S "$OUT/${MODULE}"
+fi
 
 for ARCH in arm64 arm64e; do
     OBJDIR="$SRC/build-$ARCH"


### PR DESCRIPTION
## What changed

- add a GitHub Actions matrix that builds and uploads separate rootless and RootHide `.deb` packages
- build RootHide with `roothide/theos`, `iphoneos-arm64e` metadata, RootHide runtime linkage, and scheme-aware framework staging
- resolve jailbreak paths through a small Objective-C bridge: `libroot` remains the rootless implementation and `libroothide` is used only for RootHide
- give the RootHide SwiftProtobuf framework a `.jbroot` install name, RootHide framework rpath, and the signature required for injected dependencies
- isolate experimental ad-service hooks only in RootHide builds and capability-gate each target, preventing one unavailable Spotify service from making Orion abort application startup

## Why

A package produced with the normal rootless toolchain can install under RootHide but does not have RootHide-compatible paths, architecture metadata, or dependency loading. The first RootHide package also exposed an Orion startup failure: the experimental ad hooks were activated as one atomic group, so one unavailable service descriptor caused a fatal error.

The RootHide-specific behavior is guarded by the `roothide` package scheme / `ROOTHIDE` Swift define. The classic rootless build keeps its existing `@rpath` framework install name, unsigned framework build step, and original single Orion ad-hook group.

## Validation

- GitHub Actions rootless build: passed
- GitHub Actions RootHide build: passed
- generated RootHide package reports `Architecture: iphoneos-arm64e`
- verified RootHide dylib dependencies and `.jbroot/Library/Frameworks` rpath with `otool`
- verified the bundled EeveeSwiftProtobuf binary has an embedded code signature
- tested successfully on RootHide, iOS 16.1.2, Spotify 9.1.44

Validation run: https://github.com/Mystlife/EeveeSpotifyReincarnated/actions/runs/29781350641